### PR TITLE
Adding sender and amount to receive callback msg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod contract;
 pub mod msg;
 mod rand;
-pub mod state;
 pub mod receiver;
+pub mod state;
 mod utils;
 mod viewing_key;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod contract;
 pub mod msg;
 mod rand;
 pub mod state;
+pub mod receiver;
 mod utils;
 mod viewing_key;
 

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -13,6 +13,14 @@ pub struct Snip20ReceiveMsg {
 }
 
 impl Snip20ReceiveMsg {
+    pub fn new(sender: HumanAddr, amount: Uint128, msg: Option<Binary>) -> Self {
+        Self {
+            sender,
+            amount,
+            msg,
+        }
+    }
+
     /// serializes the message
     pub fn into_binary(self) -> StdResult<Binary> {
         let msg = ReceiverHandleMsg::Receive(self);
@@ -21,12 +29,15 @@ impl Snip20ReceiveMsg {
 
     /// creates a cosmos_msg sending this struct to the named contract
     pub fn into_cosmos_msg(
-        self, contract_code_hash: String, contract_addr: HumanAddr) -> StdResult<CosmosMsg> {
+        self,
+        callback_code_hash: String,
+        contract_addr: HumanAddr,
+    ) -> StdResult<CosmosMsg> {
         let msg = self.into_binary()?;
         let execute = WasmMsg::Execute {
             msg,
-            callback_code_hash: contract_code_hash,
-            contract_addr: contract_addr,
+            callback_code_hash,
+            contract_addr,
             send: vec![],
         };
         Ok(execute.into())

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,0 +1,41 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{to_binary, Binary, CosmosMsg, HumanAddr, StdResult, Uint128, WasmMsg};
+
+/// Snip20ReceiveMsg should be de/serialized under `Receive()` variant in a HandleMsg
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct Snip20ReceiveMsg {
+    pub sender: HumanAddr,
+    pub amount: Uint128,
+    pub msg: Option<Binary>,
+}
+
+impl Snip20ReceiveMsg {
+    /// serializes the message
+    pub fn into_binary(self) -> StdResult<Binary> {
+        let msg = ReceiverHandleMsg::Receive(self);
+        to_binary(&msg)
+    }
+
+    /// creates a cosmos_msg sending this struct to the named contract
+    pub fn into_cosmos_msg(
+        self, contract_code_hash: String, contract_addr: HumanAddr) -> StdResult<CosmosMsg> {
+        let msg = self.into_binary()?;
+        let execute = WasmMsg::Execute {
+            msg,
+            callback_code_hash: contract_code_hash,
+            contract_addr: contract_addr,
+            send: vec![],
+        };
+        Ok(execute.into())
+    }
+}
+
+// This is just a helper to properly serialize the above message
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+enum ReceiverHandleMsg {
+    Receive(Snip20ReceiveMsg),
+}


### PR DESCRIPTION
Updated Send/SendFrom to provide the Receive function the sender, amount, and an optional msg the user may provide using the format:
`pub struct Snip20ReceiveMsg {
    pub sender: HumanAddr,
    pub amount: Uint128,
    pub msg: Option<Binary>,
}`
sent in a Receive HandleMsg